### PR TITLE
fix: Implement client-side ticking and further stabilize timer

### DIFF
--- a/break-enforcer.js
+++ b/break-enforcer.js
@@ -1,7 +1,7 @@
 class BreakEnforcer {
   constructor() {
     this.breakOverlayVisible = false;
-    // REMOVED: this.breakCountdownInterval = null;
+    this.countdownInterval = null;
     this.observer = null;
     this.currentState = null;
     this.activeOverlaySettings = {};
@@ -205,6 +205,38 @@ class BreakEnforcer {
       this.updateBreakCountdown(currentTime);
     }
     this.setupOverlayObserver();
+    this.startTicking();
+  }
+
+  startTicking() {
+      this.stopTicking();
+      if (!this.currentState?.isRunning || !this.currentState?.targetCompletionTime) return;
+
+      this.countdownInterval = setInterval(() => this.tick(), 250);
+      this.tick();
+  }
+
+  stopTicking() {
+      if (this.countdownInterval) {
+          clearInterval(this.countdownInterval);
+          this.countdownInterval = null;
+      }
+  }
+
+  tick() {
+      if (!this.currentState?.targetCompletionTime) {
+          this.stopTicking();
+          return;
+      }
+
+      const remaining = this.currentState.targetCompletionTime - Date.now();
+      const remainingSeconds = Math.max(0, Math.round(remaining / 1000));
+
+      this.updateBreakCountdown(remainingSeconds);
+
+      if (remaining < 0) {
+          this.stopTicking();
+      }
   }
 
   setupOverlayObserver() {
@@ -239,6 +271,7 @@ class BreakEnforcer {
   }
 
   removeBreakOverlay() {
+    this.stopTicking();
     if (this.observer) {
         this.observer.disconnect();
         this.observer = null;


### PR DESCRIPTION
This commit addresses UI synchronization issues and further hardens the extension against timing inaccuracies related to the service worker lifecycle.

The key changes include:

- **Client-Side Countdown:** The popup (`popup.js`) and break overlay (`break-enforcer.js`) now use their own `setInterval` to manage their countdown displays. They are synchronized using the `targetCompletionTime` from the background script, ensuring their timers are always smooth and perfectly in sync. This resolves the bug where the timers could appear out of sync or lag before updating.
- **Centralized State Management:** Refactored UI scripts (`popup.js`, `options.js`, `content.js`) to fetch state exclusively from the background script, with a robust retry mechanism. This removes inconsistent fallback logic and makes `background.js` the single source of truth.
- **Optimized Stats Page:** Improved the rendering performance of the statistics page by updating only the necessary parts of the DOM instead of re-rendering the entire view.
- **Refined Settings Updates:** The `updateSettings` function in `background.js` now correctly updates the `currentTime` for the active mode (focus or break) when the timer is paused.