### PR TITLE
Fix DOM access and syntax errors

### DIFF
--- a/break-enforcer.js
+++ b/break-enforcer.js
@@ -281,7 +281,6 @@ class BreakEnforcer {
       this.breakCountdownInterval = null;
     }
   }
-  }
 
   removeBreakOverlay() {
     if (this.observer) {


### PR DESCRIPTION
This commit resolves a series of errors that were causing the extension to be unstable.

The fixes include:
- Removing an extra closing brace in `break-enforcer.js` that was causing a `SyntaxError`.
- Correcting a `ReferenceError` in `blocker.js` by using the properly scoped `window.__pomodoroBlocker` variable in the `beforeunload` listener.
- Adding defensive checks across all content scripts (`blocker.js`, `break-enforcer.js`, `content.js`) to ensure DOM elements like `document.head` and `document.body` exist before they are accessed. This prevents "Cannot read properties of null" errors.
- Ensuring that style injections in `blocker.js` wait for `DOMContentLoaded` when necessary.

These changes stabilize the content scripts, preventing them from crashing and resolving the associated "context invalidated" and connection errors.